### PR TITLE
Late penalty func stabilizes schelling deadlines

### DIFF
--- a/lib/latepenalty.js
+++ b/lib/latepenalty.js
@@ -1,53 +1,48 @@
 /*eslint-disable */
-// This code is done and tested!
 // See the spec for a graph of the credit function and the rationale for this.
 
-/* The main function here is credit(t) which computes the fraction of full
-credit you get for being t seconds late. It's roughly a continuous version of
-the following:
+/* The main function is credit(t) which computes the fraction of full credit
+you get for being t seconds late. It's roughly a continuous version of this:
   credit(t) = 1      if t<=0s  # not late so no penalty
   credit(t) = .99999 if t<60s  # seconds late (essentially no penalty)
   credit(t) = .999   if t<1h   # minutes late (baaaasically counts)
   credit(t) = .99    if t<1d   # hours late   (no big deal, almost fully counts)
   credit(t) = .9     if t<1w   # days late    (main thing is it's done)
-  credit(t) = .5     if t<1mo  # weeks late   (half counts if this late)
+  credit(t) = .5     if t<30d  # weeks late   (half counts if this late)
   credit(t) = .1     if t<1y   # months late  (mostly doesn't count)
   credit(t) = .01    if t<10y  # years late   (better late than never, barely)
   credit(t) = 0      otherwise # decades late (essentially zero credit)
 */
 
-const cSecs   = 0.99999  // how much credit you get if you're  seconds  late
-const cMins   = 0.999    //                                    minutes
-const cHours  = 0.99     //                                    hours
-const cDays   = 0.9      //                                    days
-const cWeeks  = 0.5      //                                    weeks
-const cMonths = 0.1      //                                    months
-const cYears  = 0.01     // how much credit you get if you're  years    late
+const cSecs = 0.99999  // how much credit you get if you're  seconds  late
+const cMins = 0.999    //                                    minutes
+const cHrs  = 0.99     //                                    hours
+const cDays = 0.9      //                                    days
+const cWks  = 0.5      //                                    weeks
+const cMos  = 0.1      //                                    months
+const cYrs  = 0.01     // how much credit you get if you're  years    late
+
 
 // Hand-picked magic h-values to give the lateness function sudden drops at all
 // the focal lateness thresholds (a minute late, an hour late, etc) while still
 // being continuous and strictly monotonically decreasing.
-const hSecs   = 300000  // h param for how steep the curve is if  seconds  late
-const hMins   = 3000    //                                        minutes
-const hHours  = 548     //                                        hours
-const hDays   = 32      //                                        days
-const hWeeks  = 5.4     //                                        weeks
-const hMonths = 4.2     //                                        months
-const hYears  = 4       // h param for how steep the curve is if  years    late
+const hSecs = 300000   // h param for how steep the curve is if  seconds  late
+const hMins = 3000     //                                        minutes
+const hHrs  = 548      //                                        hours
+const hDays = 32       //                                        days
+const hWks  = 5.4      //                                        weeks
+const hMos  = 4.2      //                                        months
+const hYrs  = 4        // h param for how steep the curve is if  years    late
 
-const SIH = 3600        // seconds in an hour
-const SID = 86400       // seconds in a day
-const SIW = SID*7       // seconds in a week
-const DIY = 365.25      // days in a year
-const SIM = SID*DIY/12  // seconds in a month
-const SIY = SID*DIY     // seconds in a year
+const SID = 86400      // seconds in a day
 
-const exp = Math.exp // let's not ugly up all our math
-const log = Math.log //  by littering it with "Math." prefixes
-const pow = Math.pow // (actually new javascript can do x**y for exponents)
+const exp = Math.exp   // let's not ugly up all our pretty math
+const log = Math.log   //  by littering it with "Math." prefixes
+const pow = Math.pow   // (actually new javascript can do x**y for exponents)
 
 // Linearly interpolate to return u when x=a and v when x=b
-// NOT CURRENTLY USED and in fact is equivalent to hscale with h=-1
+// This is equivalent to hscale with h=-1 and isn't used for commits.to but it's
+// nice for comparison:
 // function lscale(x, a, b, u, v) { return (b*u - a*v + (v-u)*x)/(b-a) }
 
 // Exponentially interpolate to return u when x=a and v when x=b
@@ -72,14 +67,14 @@ const hscale = function(h, x, a, b, u, v) {
 
 // Compute the credit you get for being t seconds late
 export default function credit(t) {
-  if      (t <= 0)  { return 1 } // not late at all, or early, means full credit
-  else if (t < 60)  { return hscale(hSecs,   t,   0,     60, 1,       cSecs)   }
-  else if (t < SIH) { return hscale(hMins,   t,  60,    SIH, cSecs,   cMins)   }
-  else if (t < SID) { return hscale(hHours,  t, SIH,    SID, cMins,   cHours)  }
-  else if (t < SIW) { return hscale(hDays,   t, SID,    SIW, cHours,  cDays)   }
-  else if (t < SIM) { return hscale(hWeeks,  t, SIW,    SIM, cDays,   cWeeks)  }
-  else if (t < SIY) { return hscale(hMonths, t, SIM,    SIY, cWeeks,  cMonths) }
-  else              { return hscale(hYears,  t, SIY, 10*SIY, cMonths, cYears)  }
+  if      (t <= 0)      { return 1 }  // not late at all or early => full credit
+  else if (t < 60)      { return hscale(hSecs, t, 0,      60,    1,     cSecs) }
+  else if (t < 3600)    { return hscale(hMins, t, 60,     3600,  cSecs, cMins) }
+  else if (t < SID)     { return hscale(hHrs,  t, 3600,   SID,    cMins, cHrs) }
+  else if (t < 7*SID)   { return hscale(hDays, t, SID,    7*SID,  cHrs, cDays) }
+  else if (t < 30*SID)  { return hscale(hWks,  t, 7*SID,  30*SID, cDays, cWks) }
+  else if (t < 365*SID) { return hscale(hMos,  t, 30*SID, 365*SID, cWks, cMos) }
+  else                  { return hscale(hYrs,  t, 365*SID, 10*SIY, cMos, cYrs) }
 }
 
 /* Side note:


### PR DESCRIPTION
The Schelling fences for a month and a year late should generally be at the same time of day as the original deadline -- ie, define a month as 30 days, not 30.4375, and a year as 365 days, not 365.25