### PR TITLE
Use the full url when building promise titles

### DIFF
--- a/lib/parse/promise.js
+++ b/lib/parse/promise.js
@@ -31,8 +31,6 @@ export const parsePromise = ({
 
   const text = parseText({ text: urtext })
   const { eventTitle, isAllDay, startDate } = parseSherlock({ text, timezone })
-  const what = startDate ? eventTitle : text // everything if no due date
-  const slug = parseSlug({ what, urtext })
 
   const tdue = dueDate || (startDate && moment(startDate)
     .add(+isAllDay, 'days') // turn boolean into 1 or 0
@@ -42,9 +40,9 @@ export const parsePromise = ({
   parsedPromise = {
     ...promise,
     id,
-    slug,
+    slug: parseSlug({ what: startDate ? eventTitle : text, urtext }),
     timezone,
-    what,
+    what: text,
     urtext,
     cred: parseCredit({ dueDate: tdue, finishDate: tfin }),
     tini: dateOr({ date: tini }),

--- a/test/lib/parse/promise.js
+++ b/test/lib/parse/promise.js
@@ -31,7 +31,7 @@ describe('parsePromise', () => {
       id: 'testuser/do-the-thing/by/jan-1-2020',
       slug: 'do-the-thing',
       timezone: 'etc/UTC',
-      what: 'Do the thing',
+      what: 'Do the thing by jan 1 2020',
       urtext: 'do-the-thing/by/jan-1-2020',
     }))
 
@@ -46,7 +46,7 @@ describe('parsePromise', () => {
         id: 'testuser/do-the-thing-before-leaving-work-by-1800',
         slug: 'do-the-thing-before-leaving-work',
         timezone: 'etc/UTC',
-        what: 'Do the thing before leaving work',
+        what: 'Do the thing before leaving work by 1800',
         urtext: 'do-the-thing-before-leaving-work-by-1800',
       }))
 


### PR DESCRIPTION
Fixes #191.

Sherlock does some strange parsing when building titles and often drops important parts of the title. (Most egregiously, it recently turned http://brian.commits.to/spend-10-mins-on-commits-to-by-tomorrow into just "Spend"). @chrisbutler had made a comment suggesting he wanted to improve Sherlock's parsing, but I think until that's merged in @dreeves' suggestion of excising all magic makes a lot of sense.

I'm happy to add some tests for this but I'm not very familiar with JS and couldn't find instructions in the README, could you give me some pointers for running the tests and how much coverage you're looking for?