### PR TITLE
Hide the "action" field of the edit form

### DIFF
--- a/views/partials/edit.handlebars
+++ b/views/partials/edit.handlebars
@@ -5,7 +5,7 @@
     <span>{{prettyDate promise.tdue}}</span>
   </h1>
 
-  <form action="/promises/edit" method="post" accept-charset="UTF-8" id="edit_{{promise.id}}">
+  <form action="" method="post" accept-charset="UTF-8" class="edit-promise" id="edit_{{promise.id}}">
     <div class="form-group-wrapper">
       <label for="what">Title</label>
       <input name="what" type="text" value="{{promise.what}}">
@@ -46,7 +46,7 @@
     </div>
 -->
     <input type="hidden" name="id" value="{{promise.id}}">
-    <input type="submit" class="promise-button" value="Save">
+    <input type="submit" class="promise-button" value="Save" onclick='editPromise()'>
   </form>
 </div>
 

--- a/views/partials/script.handlebars
+++ b/views/partials/script.handlebars
@@ -103,6 +103,14 @@
     })
   }
 
+  // the "action" field of the edit form is left blank until submission to
+  // protect against spam bot submissions
+  const editPromise = function() {
+    console.log('editPromise')
+    $('.edit-promise').attr('action', '/promises/edit')
+    $('.edit-promise').submit()
+  }
+
   const deletePromise = function(username, id) {
     console.log('deletePromise', id, username)
 


### PR DESCRIPTION
Bots use the form action to submit spam into forms, so we hide the
action field until a user clicks submit.

This addresses issue #230.