### PR TITLE
Issue 239 stop old due dates

### DIFF
--- a/lib/parse/promise.js
+++ b/lib/parse/promise.js
@@ -33,6 +33,7 @@ export const parsePromise = ({
   let { eventTitle, isAllDay, startDate } = parseSherlock({ text, timezone })
 
   if ( moment(startDate).isBefore(moment().subtract(1, 'years')) ) {
+    log.debug('Caught and fixed promise with old parsed start date of:', startDate)
     startDate = null; // clear startDate if more than a year ago
   }
 

--- a/lib/parse/promise.js
+++ b/lib/parse/promise.js
@@ -30,7 +30,11 @@ export const parsePromise = ({
   const { tini, tdue: dueDate, tfin } = promise
 
   const text = parseText({ text: urtext })
-  const { eventTitle, isAllDay, startDate } = parseSherlock({ text, timezone })
+  let { eventTitle, isAllDay, startDate } = parseSherlock({ text, timezone })
+
+  if ( moment(startDate).isBefore(moment().subtract(1, 'years')) ) {
+    startDate = null; // clear startDate if more than a year ago
+  }
 
   const tdue = dueDate || (startDate && moment(startDate)
     .add(+isAllDay, 'days') // turn boolean into 1 or 0


### PR DESCRIPTION
Short change to check the date that has been parsed out of a new promise by Sherlock as the date the commitment is to be completed by.  If the date is "too old" (currently coded as more than a year ago), the date is rejected, and we carry on as if no date were parsed out.