### PR TITLE
update URLs for github repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Commits.to &mdash; a.k.a. [The I-Will System](https://github.com/beeminder/iwill/)
+Commits.to &mdash; a.k.a. [The I-Will System](https://github.com/commitsto/commits.to/)
 ---
 [![CircleCI](https://circleci.com/gh/commitsto/commits.to.svg?style=svg)](https://circleci.com/gh/commitsto/commits.to)
 [![codecov](https://codecov.io/gh/commitsto/commits.to/branch/master/graph/badge.svg)](https://codecov.io/gh/commitsto/commits.to)
@@ -6,7 +6,7 @@ Commits.to &mdash; a.k.a. [The I-Will System](https://github.com/beeminder/iwill
 [![Test Coverage](https://api.codeclimate.com/v1/badges/8e0ffae4691a439960df/test_coverage)](https://codeclimate.com/github/commitsto/commits.to/test_coverage)
 
 Start with the
-[Functional Spec](https://github.com/beeminder/iwill/wiki/)
+[Functional Spec](https://github.com/commitsto/commits.to/wiki/)
 which also gives the backstory for this project.
 
 

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "name": "commits.to",
   "description": "Commitment logging and reliability tracking",
   "website": "http://commits.to",
-  "repository": "https://github.com/beeminder/iwill",
+  "repository": "https://github.com/commitsto/commits.to",
   "env": {
     "ENV_NAME": "heroku-review",
     "APP_DOMAIN": "commitsto-dev.review",

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -30,8 +30,8 @@
       </h1>
       <nav>
         <a class="button" target="_blank" href="http://blog.beeminder.com/will">blog post</a>
-        <a class="button" target="_blank" href="https://github.com/beeminder/iwill">github repo</a>
-        <a class="button" target="_blank" href="https://github.com/beeminder/iwill/wiki">spec</a>
+        <a class="button" target="_blank" href="https://github.com/commitsto/commits.to">github repo</a>
+        <a class="button" target="_blank" href="https://github.com/commitsto/commits.to/wiki">spec</a>
       </nav>
     </header>
 

--- a/views/signup.handlebars
+++ b/views/signup.handlebars
@@ -12,7 +12,7 @@
   </h2>
   <p>
     Read the 
-    <a href="https://github.com/beeminder/iwill/wiki">the spec</a>
+    <a href="https://github.com/commitsto/commits.to/wiki">the spec</a>
     or the 
     <a href="http://blog.beeminder.com/will">original blog post</a>.
   </p>


### PR DESCRIPTION
This changes all `https://github.com/beeminder/iwill/...` URLs in the code base to `https://github.com/commitsto/commits.to/...`

Most are just links shown to users in documentation, but the change to `app.json` might need a bit more careful review. I'm not sure if changing `repository` has any impact.