### PR TITLE
convert http:// to https:// for sites that automatically redirect to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Run [Mocha](https://mochajs.org/) tests with `npm test`.
 
 ### Writing tests
 
-We're using the [Chai](http://www.chaijs.com/) assertion library and [Sinon](http://sinonjs.org/) for spying/stubbing.
+We're using the [Chai](https://www.chaijs.com/) assertion library and [Sinon](https://sinonjs.org/) for spying/stubbing.
 You can run tests in watch mode to get results nearly instantly on save with `npm run test:watch`
 
 ### Structuring tests

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -29,7 +29,7 @@
         </a>
       </h1>
       <nav>
-        <a class="button" target="_blank" href="http://blog.beeminder.com/will">blog post</a>
+        <a class="button" target="_blank" href="https://blog.beeminder.com/will">blog post</a>
         <a class="button" target="_blank" href="https://github.com/commitsto/commits.to">github repo</a>
         <a class="button" target="_blank" href="https://github.com/commitsto/commits.to/wiki">spec</a>
       </nav>

--- a/views/signup.handlebars
+++ b/views/signup.handlebars
@@ -7,13 +7,13 @@
     </p>
     <p>
       For more help, also consider joining our <a href="http://slack.commits.to">Slack channel</a>
-      and checking the <a href="http://forum.beeminder.com/c/commitsto">Beeminder forum</a>.
+      and checking the <a href="https://forum.beeminder.com/c/commitsto">Beeminder forum</a>.
     </p>
   </h2>
   <p>
     Read the 
     <a href="https://github.com/commitsto/commits.to/wiki">the spec</a>
     or the 
-    <a href="http://blog.beeminder.com/will">original blog post</a>.
+    <a href="https://blog.beeminder.com/will">original blog post</a>.
   </p>
 </main>


### PR DESCRIPTION
The main point of this PR is to change the forum.beeminder.com link from http to https since that's been recently discussed in Beeminder slack.

I also changed the links to all sites that automatically redirect to https. It's a really minor thing but it prevents the visible redirection in the user's browser and avoids any possibility of future problems if the web servers stop listening on port 80.